### PR TITLE
Add web-based prototype structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Juego3D
+
+Este proyecto es un prototipo web para el juego "Cambio de Gravedad en Tiempo Real". Utiliza HTML5, CSS y JavaScript para probar las mecánicas básicas de rotación de gravedad.
+
+## Estructura
+
+- `index.html`: página principal con un lienzo WebGL.
+- `js/main.js`: lógica de juego y control de gravedad.
+- `css/styles.css`: estilos generales.
+
+## Uso
+
+Abre `index.html` en un navegador moderno. Puedes usar una herramienta de servidor estático como `npx serve` para evitar problemas de CORS al cargar módulos.
+
+En el prototipo inicial se muestra una caja que representa al jugador. Usa las flechas izquierda y derecha para girar el vector de gravedad y observar el cambio en la física.
+

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,13 @@
+body {
+    margin: 0;
+    overflow: hidden;
+    background: #101820;
+    color: #fff;
+    font-family: sans-serif;
+}
+
+canvas {
+    display: block;
+    width: 100vw;
+    height: 100vh;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cambio de Gravedad</title>
+    <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+    <canvas id="gameCanvas"></canvas>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js"></script>
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,39 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js';
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('gameCanvas') });
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const geometry = new THREE.BoxGeometry(1, 1, 1);
+const material = new THREE.MeshNormalMaterial();
+const player = new THREE.Mesh(geometry, material);
+scene.add(player);
+
+camera.position.z = 5;
+let gravity = new THREE.Vector3(0, -0.01, 0);
+let velocity = new THREE.Vector3();
+
+function onKeyDown(event) {
+    if (event.key === 'ArrowLeft') {
+        gravity.set(-gravity.y, gravity.x, 0); // rotate 90 degrees left
+    } else if (event.key === 'ArrowRight') {
+        gravity.set(gravity.y, -gravity.x, 0); // rotate 90 degrees right
+    }
+}
+window.addEventListener('keydown', onKeyDown);
+
+function animate() {
+    requestAnimationFrame(animate);
+    velocity.add(gravity);
+    player.position.add(velocity);
+
+    // keep player within view bounds
+    if (player.position.length() > 10) {
+        player.position.set(0, 0, 0);
+        velocity.set(0, 0, 0);
+    }
+    renderer.render(scene, camera);
+}
+
+animate();


### PR DESCRIPTION
## Summary
- add basic README instructions
- create starter `index.html`, `css/styles.css`, and `js/main.js`
- prototype simple gravity rotation mechanic using Three.js

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68597936c4748331ab1d53e0d648de13