### PR TITLE
Add basic HUD overlays

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,8 +5,52 @@ body {
     align-items: center;
     height: 100vh;
     background-color: #202020;
+    position: relative;
+    font-family: Arial, sans-serif;
 }
 
 canvas {
+    border: 1px solid #fff;
+}
+
+#hud {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    pointer-events: none;
+    color: #fff;
+}
+
+#energyContainer {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 200px;
+    height: 20px;
+    background-color: #444;
+    border: 1px solid #fff;
+}
+
+#energyBar {
+    height: 100%;
+    width: 100%;
+    background-color: #0f0;
+}
+
+#gravityCounter {
+    position: absolute;
+    top: 40px;
+    left: 10px;
+    font-size: 14px;
+}
+
+#minimap {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 150px;
+    height: 150px;
+    background-color: rgba(255, 255, 255, 0.1);
     border: 1px solid #fff;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
 </head>
 <body>
     <canvas id="gameCanvas" width="800" height="600"></canvas>
+    <div id="hud">
+        <div id="energyContainer">
+            <div id="energyBar"></div>
+        </div>
+        <div id="gravityCounter">Gravity Changes: <span id="gravityRemaining">0</span></div>
+        <div id="minimap"></div>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
     <script src="js/core/gravity-controller.js"></script>
     <script src="js/entities/player.js"></script>


### PR DESCRIPTION
## Summary
- add HUD markup to overlay energy, gravity counter and minimap
- style HUD elements and position them on top of the canvas

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859869bf5d08331b0ccfbe4e536372f