### PR TITLE
Add start screen and pause overlay

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -54,3 +54,52 @@ canvas {
     background-color: rgba(255, 255, 255, 0.1);
     border: 1px solid #fff;
 }
+
+#startScreen,
+#pauseOverlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    transition: opacity 0.3s ease;
+    pointer-events: auto;
+}
+
+#startScreen.hidden {
+    opacity: 0;
+    visibility: hidden;
+}
+
+#pauseOverlay {
+    opacity: 0;
+    visibility: hidden;
+}
+
+#pauseOverlay.visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+#pauseBtn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 10;
+}
+
+.mobile-only {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    .mobile-only {
+        display: block;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
+    <div id="startScreen">
+        <button id="startButton">Jugar</button>
+        <button id="optionsButton">Opciones</button>
+    </div>
+    <div id="pauseOverlay">Pausado</div>
+    <button id="pauseBtn" class="mobile-only">II</button>
     <canvas id="gameCanvas" width="800" height="600"></canvas>
     <div id="hud">
         <div id="energyContainer">

--- a/js/core/game.js
+++ b/js/core/game.js
@@ -12,6 +12,7 @@ class Game {
         this.renderer.setSize(this.canvas.clientWidth, this.canvas.clientHeight);
 
         this.clock = new THREE.Clock();
+        this.paused = false;
         this.gravity = new GravityController();
         this.player = new Player();
         this.scene.add(this.player.mesh);
@@ -24,6 +25,10 @@ class Game {
         window.addEventListener('resize', () => this._onResize());
         this._onResize();
         requestAnimationFrame(this.animate);
+    }
+
+    togglePause() {
+        this.paused = !this.paused;
     }
 
     _setupScene() {
@@ -65,10 +70,12 @@ class Game {
         requestAnimationFrame(this.animate);
         const delta = this.clock.getDelta();
 
-        this.player.update(delta, this.keys, this.gravity, this.level.getCollidables());
-        this.level.update(delta, this.player);
-        this.camera.position.addScaledVector(this.player.velocity, delta);
-        this.camera.lookAt(this.player.mesh.position);
+        if (!this.paused) {
+            this.player.update(delta, this.keys, this.gravity, this.level.getCollidables());
+            this.level.update(delta, this.player);
+            this.camera.position.addScaledVector(this.player.velocity, delta);
+            this.camera.lookAt(this.player.mesh.position);
+        }
         this.renderer.render(this.scene, this.camera);
     }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,34 @@
 window.addEventListener('load', () => {
-    new Game();
+    const startScreen = document.getElementById('startScreen');
+    const startButton = document.getElementById('startButton');
+    const optionsButton = document.getElementById('optionsButton');
+    const pauseOverlay = document.getElementById('pauseOverlay');
+    const pauseBtn = document.getElementById('pauseBtn');
+    let game = null;
+
+    const togglePause = () => {
+        if (!game) return;
+        game.togglePause();
+        if (game.paused) {
+            pauseOverlay.classList.add('visible');
+        } else {
+            pauseOverlay.classList.remove('visible');
+        }
+    };
+
+    startButton.addEventListener('click', () => {
+        startScreen.classList.add('hidden');
+        if (!game) game = new Game();
+    });
+
+    optionsButton.addEventListener('click', () => {
+        alert('Opciones no implementadas');
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.code === 'Escape') {
+            togglePause();
+        }
+    });
+    pauseBtn.addEventListener('click', togglePause);
 });


### PR DESCRIPTION
## Summary
- add start screen with **Jugar** and **Opciones** buttons
- implement pause overlay triggered by Escape key or button
- use CSS transitions for overlays

## Testing
- `npx serve -s` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_68598a439fb483319357b99a9d00870d