### PR TITLE
Add touch and gamepad controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -98,6 +98,22 @@ canvas {
     display: none;
 }
 
+#touchControls {
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 5px;
+    pointer-events: auto;
+}
+
+#touchControls button {
+    width: 40px;
+    height: 40px;
+    font-size: 12px;
+}
+
 @media (max-width: 600px) {
     .mobile-only {
         display: block;

--- a/index.html
+++ b/index.html
@@ -21,7 +21,15 @@
         <div id="gravityCounter">Gravity Changes: <span id="gravityRemaining">0</span></div>
         <div id="minimap"></div>
     </div>
+    <div id="touchControls" class="mobile-only">
+        <button id="btnJump">Jump</button>
+        <button id="btnDash">Dash</button>
+        <button id="btnRotX">GX</button>
+        <button id="btnRotY">GY</button>
+        <button id="btnRotZ">GZ</button>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+    <script src="js/core/input-handler.js"></script>
     <script src="js/core/gravity-controller.js"></script>
     <script src="js/entities/player.js"></script>
     <script src="js/entities/MovingPlatform.js"></script>

--- a/js/core/game.js
+++ b/js/core/game.js
@@ -37,25 +37,8 @@ class Game {
     }
 
     _setupControls() {
-        this.keys = {};
-        window.addEventListener('keydown', (e) => {
-            this.keys[e.code] = true;
-            if (e.code === 'KeyG') {
-                this.gravity.rotate('x');
-                this.player.onGravityChange(this.gravity.vector);
-            }
-            if (e.code === 'KeyH') {
-                this.gravity.rotate('y');
-                this.player.onGravityChange(this.gravity.vector);
-            }
-            if (e.code === 'KeyJ') {
-                this.gravity.rotate('z');
-                this.player.onGravityChange(this.gravity.vector);
-            }
-        });
-        window.addEventListener('keyup', (e) => {
-            this.keys[e.code] = false;
-        });
+        this.input = new InputHandler();
+        this.keys = this.input.keys;
     }
 
     _onResize() {
@@ -71,7 +54,27 @@ class Game {
         const delta = this.clock.getDelta();
 
         if (!this.paused) {
-            this.player.update(delta, this.keys, this.gravity, this.level.getCollidables());
+            this.input.update();
+
+            if (this.input.wasPressed('KeyG')) {
+                this.gravity.rotate('x');
+                this.player.onGravityChange(this.gravity.vector);
+            }
+            if (this.input.wasPressed('KeyH')) {
+                this.gravity.rotate('y');
+                this.player.onGravityChange(this.gravity.vector);
+            }
+            if (this.input.wasPressed('KeyJ')) {
+                this.gravity.rotate('z');
+                this.player.onGravityChange(this.gravity.vector);
+            }
+
+            const actions = {
+                jump: this.input.wasPressed('Space'),
+                dash: this.input.wasPressed('KeyK'),
+            };
+
+            this.player.update(delta, this.keys, this.gravity, this.level.getCollidables(), actions);
             this.level.update(delta, this.player);
             this.camera.position.addScaledVector(this.player.velocity, delta);
             this.camera.lookAt(this.player.mesh.position);

--- a/js/core/input-handler.js
+++ b/js/core/input-handler.js
@@ -1,0 +1,74 @@
+class InputHandler {
+    constructor() {
+        this.keys = {};
+        this.justPressed = {};
+        this._setupKeyboard();
+        this._setupTouch();
+    }
+
+    _setKey(code, pressed) {
+        if (pressed) {
+            if (!this.keys[code]) {
+                this.justPressed[code] = true;
+            }
+            this.keys[code] = true;
+        } else {
+            this.keys[code] = false;
+        }
+    }
+
+    _setupKeyboard() {
+        window.addEventListener('keydown', e => this._setKey(e.code, true));
+        window.addEventListener('keyup', e => this._setKey(e.code, false));
+    }
+
+    _setupTouch() {
+        const map = (id, code) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            const start = ev => { ev.preventDefault(); this._setKey(code, true); };
+            const end = ev => { ev.preventDefault(); this._setKey(code, false); };
+            el.addEventListener('touchstart', start);
+            el.addEventListener('touchend', end);
+            el.addEventListener('touchcancel', end);
+        };
+        map('btnJump', 'Space');
+        map('btnDash', 'KeyK');
+        map('btnRotX', 'KeyG');
+        map('btnRotY', 'KeyH');
+        map('btnRotZ', 'KeyJ');
+    }
+
+    update() {
+        this._updateGamepad();
+    }
+
+    _updateGamepad() {
+        const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+        const gp = pads[0];
+        if (!gp) return;
+        this._setKey('Space', gp.buttons[0]?.pressed);
+        this._setKey('KeyJ', gp.buttons[1]?.pressed);
+        this._setKey('KeyK', gp.buttons[2]?.pressed);
+        this._setKey('KeyG', gp.buttons[4]?.pressed);
+        this._setKey('KeyH', gp.buttons[5]?.pressed);
+
+        const dz = 0.2;
+        const ax = gp.axes[0] || 0;
+        const ay = gp.axes[1] || 0;
+        this._setKey('ArrowLeft', ax < -dz);
+        this._setKey('ArrowRight', ax > dz);
+        this._setKey('ArrowUp', ay < -dz);
+        this._setKey('ArrowDown', ay > dz);
+    }
+
+    wasPressed(code) {
+        if (this.justPressed[code]) {
+            this.justPressed[code] = false;
+            return true;
+        }
+        return false;
+    }
+}
+
+window.InputHandler = InputHandler;

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -21,7 +21,7 @@ class Player {
      * @param {object} keys - dictionary with pressed keys
      * @param {GravityController} gravity
      */
-    update(delta, keys, gravity, collidables = []) {
+    update(delta, keys, gravity, collidables = [], actions = {}) {
         const speed = 5;
         if (keys['ArrowLeft'] || keys['KeyA']) {
             this.velocity.x -= speed * delta;
@@ -36,10 +36,11 @@ class Player {
             this.velocity.z += speed * delta;
         }
 
-        if (keys['Space']) {
+        if (actions.jump) {
             this.jump(gravity.vector);
-            // Prevent continuous jumping while the key is held down
-            keys['Space'] = false;
+        }
+        if (actions.dash) {
+            this.dash();
         }
 
         // Apply gravity and integrate velocity
@@ -74,6 +75,21 @@ class Player {
         const dashStrength = 8;
         const impulse = newGravity.clone().normalize().multiplyScalar(dashStrength);
         this.velocity.add(impulse);
+    }
+
+    /**
+     * Dash in the current horizontal movement direction.
+     */
+    dash() {
+        const dir = this.velocity.clone();
+        dir.y = 0;
+        if (dir.lengthSq() === 0) {
+            dir.set(0, 0, -1);
+        } else {
+            dir.normalize();
+        }
+        const dashStrength = 8;
+        this.velocity.addScaledVector(dir, dashStrength);
     }
 
     /**


### PR DESCRIPTION
## Summary
- create `InputHandler` for keyboard, touch and Gamepad input
- update `Game` to use new handler and trigger gravity, jump and dash actions
- implement dash ability in `Player`
- add on-screen touch buttons
- style touch buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859984449648331b6cd44ef44e12b2c