### PR TITLE
Add narrative and asset guideline docs

### DIFF
--- a/docs/ART_AUDIO_GUIDELINES.md
+++ b/docs/ART_AUDIO_GUIDELINES.md
@@ -1,0 +1,18 @@
+# Art and Audio Guidelines
+
+These guidelines capture the visual and sound direction specified in the design document.
+
+## Visual Style
+
+- **Low Poly Assets** – Environments and characters use simple geometry with minimal textures to maintain readability.
+- **Color Palette** – Laboratory surfaces stay neutral gray while hazards use bright accent colors. Power-ups and interactive objects should stand out.
+- **File Formats** – Prefer `.glb` or `.obj` for 3D models. Textures remain small (`512x512` or less) and use PNG.
+
+## Audio
+
+- **Effects** – Short clips for actions like jumping, rotating gravity and picking up items. Keep them under 2 seconds in length.
+- **Music** – A looping background track for each level; aim for 30–60 seconds per loop.
+- **File Naming** – Use `jump.wav`, `gravity.wav`, `pickup.wav` and `background.wav` placed in `assets/audio` as referenced in the project README.
+- **Format** – 44.1 kHz stereo WAV or OGG files.
+
+Following these standards ensures all assets integrate smoothly with the existing codebase.

--- a/docs/NARRATIVE.md
+++ b/docs/NARRATIVE.md
@@ -1,0 +1,16 @@
+# Narrative Overview
+
+This document summarizes the game's story structure based on the design document.
+
+## Premise
+
+The player controls a test subject trapped in a research facility where gravity experiments have gone awry. Using a prototype gravity device, the protagonist must navigate a series of test chambers to escape.
+
+## Structure
+
+1. **Introduction** – Tutorial levels introduce movement and gravity rotation.
+2. **Experiment Floors** – Progressively challenging chambers require puzzle solving and platforming under shifting gravity.
+3. **Escape Sequence** – Final levels combine earlier mechanics in a timed run to exit the facility.
+4. **Resolution** – The player escapes to the surface, hinting at further adventures.
+
+Each stage features minimal cutscene text delivered through terminal screens in the environment.


### PR DESCRIPTION
## Summary
- document story structure in `docs/NARRATIVE.md`
- outline art style and audio specs in `docs/ART_AUDIO_GUIDELINES.md`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859aa0bdef883319c6de58cc9a48148