### PR TITLE
Add basic 3D models and loaders

### DIFF
--- a/assets/models/README.md
+++ b/assets/models/README.md
@@ -1,0 +1,8 @@
+This folder stores 3D models used by the game.
+Placeholders for the main characters and drone are included:
+
+- `alex_vega.glb`
+- `marcus_thorne.glb`
+- `drone.glb`
+
+Replace these with real GLB files as they become available.

--- a/assets/models/alex_vega.glb
+++ b/assets/models/alex_vega.glb
@@ -1,0 +1,1 @@
+Placeholder GLB for Alex Vega

--- a/assets/models/drone.glb
+++ b/assets/models/drone.glb
@@ -1,0 +1,1 @@
+Placeholder GLB for Anti-Gravity Drone

--- a/assets/models/marcus_thorne.glb
+++ b/assets/models/marcus_thorne.glb
@@ -1,0 +1,1 @@
+Placeholder GLB for Marcus Thorne

--- a/index.html
+++ b/index.html
@@ -30,10 +30,13 @@
         <button id="btnRotZ">GZ</button>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/loaders/GLTFLoader.js"></script>
     <script src="js/core/audio-manager.js"></script>
     <script src="js/core/input-handler.js"></script>
     <script src="js/core/gravity-controller.js"></script>
     <script src="js/entities/player.js"></script>
+    <script src="js/entities/EnemyDrone.js"></script>
+    <script src="js/entities/MarcusThorne.js"></script>
     <script src="js/entities/MovingPlatform.js"></script>
     <script src="js/entities/PowerUp.js"></script>
     <script src="js/levels/level01.js"></script>

--- a/js/entities/EnemyDrone.js
+++ b/js/entities/EnemyDrone.js
@@ -1,0 +1,35 @@
+class EnemyDrone {
+    constructor(position = new THREE.Vector3()) {
+        this.mesh = new THREE.Group();
+        this.mesh.position.copy(position);
+
+        const placeholder = new THREE.Mesh(
+            new THREE.SphereGeometry(0.5, 8, 8),
+            new THREE.MeshBasicMaterial({ color: 0xff0000 })
+        );
+        this.mesh.add(placeholder);
+
+        const loader = new THREE.GLTFLoader();
+        loader.load(
+            'assets/models/drone.glb',
+            (gltf) => {
+                this.mesh.remove(placeholder);
+                this.mesh.add(gltf.scene);
+            },
+            undefined,
+            (err) => console.error('Failed to load drone model', err)
+        );
+
+        this.speed = 1;
+        this.direction = 1;
+    }
+
+    update(delta) {
+        this.mesh.position.x += this.direction * this.speed * delta;
+        if (Math.abs(this.mesh.position.x) > 5) {
+            this.direction *= -1;
+        }
+    }
+}
+
+window.EnemyDrone = EnemyDrone;

--- a/js/entities/MarcusThorne.js
+++ b/js/entities/MarcusThorne.js
@@ -1,0 +1,29 @@
+class MarcusThorne {
+    constructor(position = new THREE.Vector3()) {
+        this.mesh = new THREE.Group();
+        this.mesh.position.copy(position);
+
+        const placeholder = new THREE.Mesh(
+            new THREE.BoxGeometry(0.8, 1.6, 0.4),
+            new THREE.MeshBasicMaterial({ color: 0x00ff00 })
+        );
+        this.mesh.add(placeholder);
+
+        const loader = new THREE.GLTFLoader();
+        loader.load(
+            'assets/models/marcus_thorne.glb',
+            (gltf) => {
+                this.mesh.remove(placeholder);
+                this.mesh.add(gltf.scene);
+            },
+            undefined,
+            (err) => console.error('Failed to load Marcus Thorne model', err)
+        );
+    }
+
+    update(delta) {
+        this.mesh.rotation.y += delta;
+    }
+}
+
+window.MarcusThorne = MarcusThorne;

--- a/js/entities/player.js
+++ b/js/entities/player.js
@@ -1,8 +1,24 @@
 class Player {
     constructor() {
-        const geometry = new THREE.BoxGeometry(1, 1, 1);
-        const material = new THREE.MeshNormalMaterial();
-        this.mesh = new THREE.Mesh(geometry, material);
+        // Container used while the model loads
+        this.mesh = new THREE.Group();
+        const placeholder = new THREE.Mesh(
+            new THREE.BoxGeometry(1, 1, 1),
+            new THREE.MeshNormalMaterial()
+        );
+        this.mesh.add(placeholder);
+
+        // Load Alex Vega model
+        const loader = new THREE.GLTFLoader();
+        loader.load(
+            'assets/models/alex_vega.glb',
+            (gltf) => {
+                this.mesh.remove(placeholder);
+                this.mesh.add(gltf.scene);
+            },
+            undefined,
+            (err) => console.error('Failed to load Alex Vega model', err)
+        );
 
         // Velocity is integrated each frame in Game.animate
         this.velocity = new THREE.Vector3();


### PR DESCRIPTION
## Summary
- add placeholder GLB models under `assets/models`
- load Alex Vega model via `GLTFLoader` in `Player`
- implement `EnemyDrone` and `MarcusThorne` entities
- include loader and new scripts in `index.html`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6859b3e9d54c8331a7a48e63b568032c